### PR TITLE
fix: do not process finished results when runjob_lockfile exists

### DIFF
--- a/libpredweb/qd_fe_common.py
+++ b/libpredweb/qd_fe_common.py
@@ -579,7 +579,10 @@ def CreateRunJoblog(loop, isOldRstdirDeleted, g_params):#{{{
 
             # if loop == 0 , for new_waitjob_list and new_runjob_list
             # re-generate finished_seqs.txt
-            if loop == 0 and os.path.exists(outpath_result):#{{{
+            runjob_lockfile = "%s/%s.lock"%(rstdir, "runjob.lock")
+            if 'DEBUG' in g_params and g_params['DEBUG'] and os.path.exists(runjob_lockfile):
+                webcom.loginfo("runjob_lockfile %s exists. "%(runjob_lockfile), gen_logfile)
+            if loop == 0 and os.path.exists(outpath_result) and not os.path.exists(runjob_lockfile):#{{{
                 finished_seq_file = "%s/finished_seqs.txt"%(outpath_result)
                 finished_idx_file = "%s/finished_seqindex.txt"%(rstdir)
                 finished_idx_set = set([])


### PR DESCRIPTION
This PR make sure that when runjob.lock exist, archived results will not be processed. 