### PR TITLE
Not connecting to a node until next loop when it is offline

### DIFF
--- a/libpredweb/qd_fe_common.py
+++ b/libpredweb/qd_fe_common.py
@@ -572,9 +572,13 @@ def SubmitJob(jobid, cntSubmitJobDict, numseq_this_user, g_params):  # {{{
         iNode = -1
         for node in cntSubmitJobDict:
             iNode += 1
+            node_status = cntSubmitJobDict[node][3]
             if "DEBUG" in g_params and g_params['DEBUG']:
                 webcom.loginfo(f"Trying to submit job to the node {iNode}: {node}", gen_logfile)
                 webcom.loginfo(f"cntSubmitJobDict={cntSubmitJobDict}", gen_logfile)
+            if node_status == "OFF":
+                webcom.loginfo(f"node {node} is offline, try again in the next loop", gen_logfile)
+                continue
             if iToRun >= numToRun:
                 if "DEBUG" in g_params and g_params['DEBUG']:
                     webcom.loginfo(f"iToRun({iToRun}) >= numToRun({numToRun}). Stop SubmitJob for jobid={jobid}", gen_logfile)
@@ -584,6 +588,7 @@ def SubmitJob(jobid, cntSubmitJobDict, numseq_this_user, g_params):  # {{{
                 myclient = Client(wsdl_url, cache=None, timeout=30)
             except Exception as e:
                 webcom.loginfo(f"Failed to access {wsdl_url}, detailed error: {e}", gen_logfile)
+                cntSubmitJobDict[node][3] = "OFF"
                 continue
 
             if "DEBUG" in g_params and g_params['DEBUG']:

--- a/libpredweb/webserver_common.py
+++ b/libpredweb/webserver_common.py
@@ -3241,3 +3241,24 @@ def get_results_eachseq(request, name_resultfile, name_nicetopfile, jobid, seqin
     resultdict['jobcounter'] = GetJobCounter(resultdict)
     return resultdict
 #}}}
+
+def InitCounterSubmitJobDict(avail_computenode, remotequeueDict, MAX_SUBMIT_JOB_PER_NODE):
+    """Initialize the dictionary which keeps track of job submission status of all backend nodes
+    """
+    # format of cntSubmitJobDict
+    # {
+    #    'node_ip': [ num_queue_job, MAX_SUBMIT_JOB_PER_NODE, queue_method, status (on or off)
+    # }
+    # format of remotequeueDict
+    # { 'node_ip': [remotejobid, remotejobid, ...] }
+    # the initial status of each node is ON, it will be set to OFF when it
+    # is failed to acess and continue as OFF for the whole loop
+    cntSubmitJobDict = {}
+    for node in avail_computenode:
+        queue_method = avail_computenode[node]['queue_method']
+        num_queue_job = len(remotequeueDict[node])
+        if num_queue_job >= 0:
+            cntSubmitJobDict[node] = [num_queue_job, MAX_SUBMIT_JOB_PER_NODE, queue_method, "ON"]
+        else:
+            cntSubmitJobDict[node] = [0, MAX_SUBMIT_JOB_PER_NODE, queue_method, "ON"]
+    return cntSubmitJobDict


### PR DESCRIPTION
This PR adds a status tracker for each backend node, so that when a node is offline, it will be skipped in job  submission until next loop. 

If not, when there are thousands of jobs in the queue, each connection to the offline node may take 1 second and it takes half an hour for each loop. 